### PR TITLE
Add google meet support (remove reliance on src attribute)

### DIFF
--- a/src/modules/observers.js
+++ b/src/modules/observers.js
@@ -5,6 +5,7 @@ import { disableVideo, enableVideo, isImageTooSmall, listenToEvent, processNode,
 import { applyBlurryStart } from "./style.js";
 import { processImage, processVideo } from "./processing2.js";
 import { STATUSES } from "../constants.js";
+
 let mutationObserver, _settings;
 let videosInProcess = [];
 
@@ -21,7 +22,7 @@ const startObserving = () => {
 };
 
 const initMutationObserver = () => {
-	// if (mutationObserver) mutationObserver.disconnect();
+  // if (mutationObserver) mutationObserver.disconnect();
 	mutationObserver = new MutationObserver((mutations) => {
 		mutations.forEach((mutation) => {
 			if (mutation.type === "childList") {
@@ -31,7 +32,7 @@ const initMutationObserver = () => {
 					});
 				});
 			} else if (mutation.type === "attributes") {
-				// if the src attribute of an image or video changes, process it
+			  // if the src attribute of an image or video changes, process it
 				const node = mutation.target;
 				observeNode(node, mutation?.attributeName === "src");
 			}
@@ -47,18 +48,18 @@ const attachObserversListener = () => {
 			mutationObserver?.disconnect();
 			mutationObserver = null;
 		} else {
-			// if observing isn't already started, start it
+		  // if observing isn't already started, start it
 			if (!mutationObserver) startObserving();
 		}
 	});
 	listenToEvent("toggleOnOffStatus", () => {
-		// console.log("HB== Observers Listener", _settings.shouldDetect());
+	  // console.log("HB== Observers Listener", _settings.shouldDetect());
 		if (!_settings?.shouldDetect()) {
-			// console.log("HB== Observers Listener", "disconnecting");
+		  // console.log("HB== Observers Listener", "disconnecting");
 			mutationObserver?.disconnect();
 			mutationObserver = null;
 		} else {
-			// if observing isn't already started, start it
+		  // if observing isn't already started, start it
 			if (!mutationObserver) startObserving();
 		}
 	});
@@ -68,7 +69,7 @@ const attachObserversListener = () => {
 		if (request.type === "disable-detection") {
 			videosInProcess
 				.filter(
-					// filter videos that are playing, not disabled and in process
+				  // filter videos that are playing, not disabled and in process
 					(video) =>
 						video.dataset.HBstatus === STATUSES.PROCESSING &&
 						!video.paused &&
@@ -76,18 +77,17 @@ const attachObserversListener = () => {
 				)
 				.forEach((video) => {
 					disableVideo(video);
-				
 				});
-			} else if (request.type === "enable-detection") {
-				videosInProcess
+		} else if (request.type === "enable-detection") {
+			videosInProcess
 				.filter(
 					(video) =>
-					video.dataset.HBstatus === STATUSES.DISABLED &&
-					!video.paused &&
-					video.currentTime > 0
-					)
-					.forEach((video) => {
-						enableVideo(video);
+						video.dataset.HBstatus === STATUSES.DISABLED &&
+						!video.paused &&
+						video.currentTime > 0
+				)
+				.forEach((video) => {
+					enableVideo(video);
 				});
 		}
 		return true;
@@ -111,32 +111,31 @@ function observeNode(node, srcAttribute) {
 	)
 		return;
 
-	let sourceChildren = //some videos have source instead of src attribute
-	isVideo
-		? node.getElementsByTagName("source")?.length
-		: 0; 
-	const conditions =
-		(srcAttribute || !node.dataset.HBstatus) && // has to have a new src attribute or no HBstatus (not processed yet)
-		(node.src?.length > 0 || sourceChildren > 0) &&  // has to have a src attribute or source children
-		(isVideo? true : (!isImageTooSmall(node) || node.height === 0 || node.width === 0)); // if it's an image, it has to be big enough
+	const conditions = srcAttribute || !node.dataset.HBstatus; // has to have a new src attribute or no HBstatus (not processed yet)
+	const isValidImage = !isVideo && (!isImageTooSmall(node) || node.height === 0 || node.width === 0); // if it's an image, it has to be big enough
 
-	if (!conditions) {
-		return;
-	}
+	if (conditions && (isVideo || isValidImage)) {
+		applyBlurryStart(node);
+		node.dataset.HBstatus = STATUSES.OBSERVED;
 
-	applyBlurryStart(node);
-	node.dataset.HBstatus = STATUSES.OBSERVED;
-	
-	if (node.src?.length || sourceChildren > 0) {
-		// if there's no src attribute yet, wait for the mutation observer to catch it
-		if (node.tagName === "IMG") processImage(node, STATUSES);
-		else if (node.tagName === "VIDEO") {
+		if (isVideo) {
 			processVideo(node, STATUSES);
 			videosInProcess.push(node);
 			updateBGvideoStatus(videosInProcess);
+
+			if (!node.src) {
+				node.addEventListener("timeupdate", function onTimeUpdate() {
+					if (node.currentTime > 0) {
+						node.removeEventListener("timeupdate", onTimeUpdate);
+						processVideo(node, STATUSES);
+					}
+				});
+			}
+		} else if (node.tagName === "IMG") {
+			processImage(node, STATUSES);
 		}
 	} else {
-		// remove the HBstatus if the node has no src attribute
+	  // remove the HBstatus if the node has no src attribute
 		delete node.dataset?.HBstatus;
 	}
 }


### PR DESCRIPTION
Uses another means of detecting video playback instead of src. This allows for non-src based videos to be included in detection such as google meets. 

On a side note, editor did some weird formatting, maybe we should have a prettier config to make sure diffs are consistent across future PRs?