### PR TITLE
Fix blur until detection ends

### DIFF
--- a/src/modules/processing2.js
+++ b/src/modules/processing2.js
@@ -47,7 +47,7 @@ const processImage = (node, STATUSES) => {
             },
             (response) => {
                 // console.log("HB== handleElementProcessing", response, node)
-                removeBlurryStart(node);
+                // removeBlurryStart(node);
                 if (response.type === "error") {
                     console.warn("HB==Error while processing image", response);
                     node.dataset.HBstatus = STATUSES.ERROR;
@@ -215,7 +215,7 @@ const processVideo = async (node) => {
             canv.height = newHeight;
         }
 
-        removeBlurryStart(node);
+        // removeBlurryStart(node);
 
         // start the video detection loop but don't block the main thread
         requestIdleCB(() => {


### PR DESCRIPTION
Related to #111

Remove the call to `removeBlurryStart` in the `processImage` function.

* Comment out the `removeBlurryStart` function call in the `processImage` function to prevent the blur from being removed before the detection result is known.

